### PR TITLE
Removed auto label on bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_reports.yml
+++ b/.github/ISSUE_TEMPLATE/bug_reports.yml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: Report an issue with the a modpack.
 title: "[Bug]: "
-labels: [bug]
 body:
   - type: input
     id: modpack


### PR DESCRIPTION
This *should* just remove the automatic labeling that occurs every new bug report. I'm suggesting this change because support requests make auto labeling inefficient in this current state, since they aren't bugs. I think I can push directly to repo, but I thought might as well practice PRing x)